### PR TITLE
✨ feat(courses): add course list and detail views with topic linking

### DIFF
--- a/src/components/courses/CourseList.vue
+++ b/src/components/courses/CourseList.vue
@@ -1,0 +1,65 @@
+<template>
+  <h1 class="text-2xl font-bold mb-4">My Courses</h1>
+  <div
+    class="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 shadow rounded-md dark:bg-gray-800"
+  >
+    <Card
+      v-for="course in courseStore.courses"
+      :key="course._id"
+      class="shadow-md cursor-pointer !hover:shadow-lg transition"
+      @click="goToCourse(course._id)"
+    >
+      <template #title>
+        <h1>
+          {{ course.title }}
+        </h1>
+      </template>
+      <template #content>
+        <p class="text-sm font-bold text-gray-600">
+          {{ teachers[course._id]?.username || "Unknown" }}
+        </p>
+        <p class="text-sm text-gray-500 italic">{{ course.semester }}</p>
+        <p class="pt-2">
+          {{ course.description.substring(0, 100)
+          }}{{ course.description.length > 100 ? "..." : "" }}
+        </p>
+      </template>
+    </Card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useRouter } from "vue-router";
+import { useCourse } from "../../stores/courseStore";
+import { getUserById } from "../../services/userService";
+import type { User } from "../../types/User";
+
+const courseStore = useCourse();
+const router = useRouter();
+const teachers = ref<Record<string, User>>({});
+
+const goToCourse = (id: string) => {
+  router.push(`/courses/${id}`);
+};
+
+onMounted(async () => {
+  await courseStore.fetchCourses();
+
+  for (const course of courseStore.courses) {
+    if (course.teacher) {
+      const teacherData = await getUserById(course.teacher);
+      teachers.value[course._id] = teacherData;
+    }
+  }
+});
+</script>
+
+<style scoped>
+.p-card {
+  &:hover {
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    translate: 0 -0.2rem;
+  }
+}
+</style>

--- a/src/components/topics/TopicList.vue
+++ b/src/components/topics/TopicList.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { onMounted, watch } from 'vue';
-import { useTopicStore } from '../../stores/topicStore';
+import { onMounted, watch } from "vue";
+import { useTopicStore } from "../../stores/topicStore";
 
 const topicStore = useTopicStore();
 const { topics, loading, error, fetchTopics } = topicStore;
 
 onMounted(async () => {
   await fetchTopics();
-  console.log('Fetched topics:', topics); 
+  console.log("Fetched topics:", topics);
 });
 
 // ✅ Watch for changes in topics and log them
 watch(topics, (newTopics) => {
-  console.log('Updated topics:', newTopics);
+  console.log("Updated topics:", newTopics);
 });
 </script>
 
@@ -23,7 +23,7 @@ watch(topics, (newTopics) => {
     <div v-if="loading" class="text-blue-500 mt-4">Loading topics...</div>
     <div v-else-if="error" class="text-red-500 mt-4">{{ error }}</div>
 
-    <ul v-else class="mt-4 space-y-4" >
+    <ul v-else class="mt-4 space-y-4">
       <li
         v-for="topic in topics"
         :key="topic._id"
@@ -43,15 +43,19 @@ watch(topics, (newTopics) => {
         <h4 class="font-semibold mt-2">Course:</h4>
         <p class="text-gray-600">{{ topic.course.title }}</p>
 
-        <h4 v-if="topic.resources.length" class="font-semibold text-gray-600 mt-2">
+        <h4
+          v-if="topic.resources.length"
+          class="font-semibold text-gray-600 mt-2"
+        >
           Resources:
         </h4>
-        <ul v-if="topic.resources.length" class="list-disc ml-5">
+        <ul v-if="topic.resources.length" class="ml-5">
           <li v-for="resource in topic.resources" :key="resource._id">
+            -
             <a
               :href="resource.link"
               target="_blank"
-              class="text-blue-500 hover:underline"
+              class="text-sky-600 hover:underline"
             >
               {{ resource.title }}
             </a>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -21,13 +21,18 @@ const items = ref<MenuItem[]>([
     command: () => router.push("/"),
   },
   {
+    label: "Courses",
+    icon: "pi pi-book",
+    command: () => router.push("/courses"),
+  },
+  {
     label: "Quizzes",
     icon: "pi pi-question-circle",
     command: () => router.push("/quizzes"),
   },
   {
     label: "Topics",
-    icon: "pi pi-book",
+    icon: "pi pi-th-large",
     command: () => router.push("/topics"),
   },
   {
@@ -40,11 +45,11 @@ const items = ref<MenuItem[]>([
 </script>
 
 <template>
-  <div class="flex flex-row-reverse w-full h-screen">
+  <div class="flex flex-row-reverse w-full h-screen bg-gray-50 overflow-auto">
     <nav class="bg-gray-100 dark:bg-gray-800 p-2 space-y-4 min-w-50">
       <div class="mb-4">
         <div v-if="userStore.isAuthenticated" class="capitalize">
-          <span class="pi pi-user pr-2"> </span>
+          <span class="pi pi-graduation-cap pr-2"> </span>
           {{ userStore.user?.username }}
           <p class="flex flex-col">
             <span class="italic">
@@ -86,7 +91,7 @@ const items = ref<MenuItem[]>([
         severity="danger"
       />
     </nav>
-    <main class="w-full flex ">
+    <main class="w-full flex">
       <router-view />
     </main>
     <Login v-model:visible="showLoginModal" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,79 +1,80 @@
-import { createApp } from 'vue'
-import { createPinia } from 'pinia'
-import App from './App.vue'
-import router from './router'
-import './style.css'
+import { createApp } from "vue";
+import { createPinia } from "pinia";
+import App from "./App.vue";
+import router from "./router";
+import "./style.css";
 
-import PrimeVue from 'primevue/config';
-import Ripple from 'primevue/ripple'
-import ConfirmationService from 'primevue/confirmationservice';
-import ToastService from 'primevue/toastservice';
-import { definePreset } from '@primeuix/themes'
-import Aura from '@primeuix/themes/aura'
+import PrimeVue from "primevue/config";
+import Ripple from "primevue/ripple";
+import ConfirmationService from "primevue/confirmationservice";
+import ToastService from "primevue/toastservice";
+import { definePreset } from "@primeuix/themes";
+import Aura from "@primeuix/themes/aura";
 
-import ConfirmPopup from 'primevue/confirmpopup'
-import Toast from 'primevue/toast'
-import Button from "primevue/button"
-import FloatLabel from 'primevue/floatlabel'
-import Password from 'primevue/password'
-import InputText from 'primevue/inputtext'
-import InputNumber from 'primevue/inputnumber'
-import Checkbox from 'primevue/checkbox'
-import Textarea from 'primevue/textarea'
-import Select from 'primevue/select'
-import DataTable from 'primevue/datatable'
-import Column from 'primevue/column'
-import Dialog from 'primevue/dialog'
-import PanelMenu from 'primevue/panelmenu'
-import Panel from 'primevue/panel'
+import ConfirmPopup from "primevue/confirmpopup";
+import Toast from "primevue/toast";
+import Button from "primevue/button";
+import FloatLabel from "primevue/floatlabel";
+import Password from "primevue/password";
+import InputText from "primevue/inputtext";
+import InputNumber from "primevue/inputnumber";
+import Checkbox from "primevue/checkbox";
+import Textarea from "primevue/textarea";
+import Select from "primevue/select";
+import DataTable from "primevue/datatable";
+import Column from "primevue/column";
+import Dialog from "primevue/dialog";
+import PanelMenu from "primevue/panelmenu";
+import Panel from "primevue/panel";
+import Card from "primevue/card";
 
-
-const pinia = createPinia()
-const app = createApp(App)
+const pinia = createPinia();
+const app = createApp(App);
 const MyPreset = definePreset(Aura, {
   semantic: {
-      primary: {
-          50: '{gray.50}',
-          100: '{gray.100}',
-          200: '{gray.200}',
-          300: '{gray.300}',
-          400: '{gray.400}',
-          500: '{gray.500}',
-          600: '{gray.600}',
-          700: '{gray.700}',
-          800: '{gray.800}',
-          900: '{gray.900}',
-          950: '{gray.950}'
-      }
-  }
+    primary: {
+      50: "{gray.50}",
+      100: "{gray.100}",
+      200: "{gray.200}",
+      300: "{gray.300}",
+      400: "{gray.400}",
+      500: "{gray.500}",
+      600: "{gray.600}",
+      700: "{gray.700}",
+      800: "{gray.800}",
+      900: "{gray.900}",
+      950: "{gray.950}",
+    },
+  },
 });
 
-app.use(PrimeVue,{
+app.use(PrimeVue, {
   theme: {
-      preset: MyPreset
+    preset: MyPreset,
   },
   ripple: true,
 });
-app.directive('ripple', Ripple); 
+app.directive("ripple", Ripple);
 app.use(ConfirmationService);
 app.use(ToastService);
 
-app.component('ConfirmPopup', ConfirmPopup)
-app.component('Toast', Toast)
-app.component('Button', Button)
-app.component('FloatLabel', FloatLabel)
-app.component('Password', Password)
-app.component('InputText', InputText)
-app.component('InputNumber', InputNumber)
-app.component('Checkbox', Checkbox)
-app.component('Textarea', Textarea)
-app.component('Select', Select)
-app.component('DataTable', DataTable)
-app.component('Column', Column)
-app.component('Dialog', Dialog)
-app.component('PanelMenu', PanelMenu)
-app.component('Panel', Panel)
+app.component("ConfirmPopup", ConfirmPopup);
+app.component("Toast", Toast);
+app.component("Card", Card);
+app.component("Button", Button);
+app.component("FloatLabel", FloatLabel);
+app.component("Password", Password);
+app.component("InputText", InputText);
+app.component("InputNumber", InputNumber);
+app.component("Checkbox", Checkbox);
+app.component("Textarea", Textarea);
+app.component("Select", Select);
+app.component("DataTable", DataTable);
+app.component("Column", Column);
+app.component("Dialog", Dialog);
+app.component("PanelMenu", PanelMenu);
+app.component("Panel", Panel);
 
-app.use(router)
-app.use(pinia)
-app.mount('#app')
+app.use(router);
+app.use(pinia);
+app.mount("#app");

--- a/src/pages/CourseDetails.vue
+++ b/src/pages/CourseDetails.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from "vue";
+import { useRoute } from "vue-router";
+import { getCourseById } from "../services/courseService";
+import { getUserById } from "../services/userService";
+import { useTopicStore } from "../stores/topicStore";
+import type { Course } from "../types/Course";
+import type { Topic } from "../types/Topic";
+import type { User } from "../types/User";
+
+const route = useRoute();
+const topicStore = useTopicStore();
+const course = ref<(Course & { topics: string[] }) | null>(null);
+const teacher = ref<User | null>(null);
+const courseTopics = computed(() => {
+  if (!course.value?.topics) return [];
+  return course.value.topics
+    .map((id) => topicStore.topics.find((t) => t._id === id))
+    .filter((t): t is Topic => !!t);
+});
+
+onMounted(async () => {
+  const id = route.params.id as string;
+  const fetchedCourse = await getCourseById(id);
+  course.value = fetchedCourse as Course & { topics: string[] };
+  await topicStore.fetchTopics();
+  if (course.value?.teacher) {
+    try {
+      teacher.value = await getUserById(course.value.teacher);
+    } catch (err) {
+      console.error("Could not load teacher info:", err);
+    }
+  }
+});
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  const options: Intl.DateTimeFormatOptions = {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  };
+  return new Intl.DateTimeFormat("en-GB", options)
+    .format(date)
+    .replace(/,/g, "");
+};
+</script>
+
+<template>
+  <div v-if="course" class="p-6 shadow rounded-md bg-gray-50 dark:bg-gray-800">
+    <h1 class="text-2xl font-bold mb-4">{{ course.title }}</h1>
+    <span class="flex gap-2 text-sm">
+      <p class="mb-2">
+        <strong><i class="pi pi-thumbtack"></i></strong>
+        {{ formatDate(course.createdAt) }}
+      </p>
+      |
+      <p class="mb-4">
+        <strong><i class="pi pi-history"></i></strong>
+        {{ formatDate(course.updatedAt) }}
+      </p>
+    </span>
+    <span class="flex gap-2">
+      <p class="mb-2">
+        <strong>Teacher:</strong>
+        {{ teacher?.username || "Unknown" }}
+      </p>
+      |
+      <p class="mb-2"><strong>Semester:</strong> {{ course.semester }}</p>
+      |
+      <p class="mb-2"><strong>Scope:</strong> {{ course.scope }}</p>
+    </span>
+    <p class="mb-2">{{ course.description }}</p>
+
+    <div class="mb-4 shadow p-2 rounded">
+      <h2 class="text-lg font-semibold mb-1">
+        <i class="pi pi-clipboard"></i> Learning Objectives
+      </h2>
+      <ul class="list-disc ml-6">
+        <li v-for="(objective, i) in course.learningObjectives" :key="i">
+          {{ objective }}
+        </li>
+      </ul>
+    </div>
+
+    <div class="mb-4 shadow p-2 rounded">
+      <h2 class="text-lg font-semibold mb-1">
+        <i class="pi pi-cog"></i> Skills
+      </h2>
+      <ul class="list-disc ml-6">
+        <li v-for="(skill, i) in course.skills" :key="i">{{ skill }}</li>
+      </ul>
+    </div>
+
+    <div class="mb-4 shadow p-2 rounded">
+      <h2 class="text-lg font-semibold mb-1">
+        <i class="pi pi-trophy"></i> Competencies
+      </h2>
+      <ul class="list-disc ml-6">
+        <li v-for="(competency, i) in course.competencies" :key="i">
+          {{ competency }}
+        </li>
+      </ul>
+    </div>
+
+    <h2 class="text-xl font-semibold mb-2">
+      <i class="pi pi-th-large"></i> Topics
+    </h2>
+    <ul>
+      <li v-for="topic in courseTopics" :key="topic?._id">
+        <router-link :to="`/topics/${topic._id}`" class="text-slate-500">
+          <span class="hover:font-bold">
+            {{ topic.title || "Untitled Topic" }}
+          </span>
+        </router-link>
+      </li>
+    </ul>
+  </div>
+</template>

--- a/src/pages/Courses.vue
+++ b/src/pages/Courses.vue
@@ -1,3 +1,8 @@
+<script setup>
+import CourseList from "../components/courses/CourseList.vue";
+</script>
 <template>
-    <h1>Courses Page</h1>
-  </template>
+  <div class="p-6">
+    <CourseList />
+  </div>
+</template>

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useRoute } from "vue-router";
+import type { Topic } from "../types/Topic";
+import { getTopicById } from "../services/topicService";
+
+const route = useRoute();
+
+const topic = ref<Topic | null>(null);
+
+onMounted(async () => {
+  const id = route.params.id as string;
+  topic.value = await getTopicById(id);
+});
+</script>
+
+<template>
+  <div
+    class="p-6 shadow rounded-md bg-gray-50 dark:bg-gray-800 overflow-auto"
+    v-if="topic"
+  >
+    <h1 class="text-2xl font-bold mb-2">{{ topic.title }}</h1>
+    <span class="flex gap-2">
+      <p class="mb-2"><strong>Week:</strong> {{ topic.week }}</p>
+      |
+      <div v-if="topic.course && typeof topic.course === 'object'">
+        <strong>Course: </strong>
+        <router-link :to="`/courses/${topic.course._id}`" class="text-sky-600">
+          <span class="hover:font-bold">
+            {{ topic.course.title || "Untitled Course" }}
+          </span>
+        </router-link>
+      </div>
+    </span>
+    <p class="mb-4">{{ topic.summary || "No summary available." }}</p>
+
+    <div v-if="topic.key_points?.length" class="mb-4 shadow p-4 rounded">
+      <h2 class="font-semibold mb-1">Key Points:</h2>
+      <ul class="list-inside mb-4">
+        <li v-for="(point, index) in topic.key_points" :key="index">
+          - {{ point }}
+        </li>
+      </ul>
+    </div>
+
+    <div v-if="topic.resources?.length" class="mb-4 shadow p-4 rounded">
+      <h2 class="font-semibold mb-1">Resources:</h2>
+      <ul class="list-inside">
+        <li v-for="resource in topic.resources" :key="resource._id">
+          -
+          <a
+            :href="resource.link"
+            target="_blank"
+            class="text-sky-600 hover:underline"
+          >
+            {{ resource.title }}
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <p v-else class="text-center p-6">Loading topic details...</p>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,11 +1,11 @@
 import { createRouter, createWebHistory } from "vue-router";
 import { useUserStore } from "../stores/userStore";
-import { storeToRefs } from "pinia"; 
+import { storeToRefs } from "pinia";
 
 import Home from "../pages/Home.vue";
 import Quizzes from "../pages/Quizzes.vue";
 import Topics from "../pages/Topics.vue";
-import Login from "../components/ui/Login.vue";
+import Courses from "../pages/Courses.vue";
 
 import DefaultLayout from "../layouts/DefaultLayout.vue";
 import AdminLayout from "../layouts/AdminLayout.vue";
@@ -16,6 +16,7 @@ import AdminTopics from "../pages/admin/AdminTopics.vue";
 import AdminCourses from "../pages/admin/AdminCourses.vue";
 import AdminUsers from "../pages/admin/AdminUsers.vue";
 
+import Login from "../components/ui/Login.vue";
 import ManageTopics from "../components/admin/ManageTopics.vue";
 import ManageQuizzes from "../components/admin/ManageQuizzes.vue";
 import ManageCourses from "../components/admin/ManageCourses.vue";
@@ -29,6 +30,15 @@ const routes = [
       { path: "", component: Home },
       { path: "quizzes", component: Quizzes },
       { path: "topics", component: Topics },
+      { path: "courses", component: Courses },
+      {
+        path: "courses/:id",
+        component: () => import("../pages/CourseDetails.vue"),
+      },
+      {
+        path: "topics/:id",
+        component: () => import("../pages/TopicDetails.vue"),
+      },
     ],
   },
   { path: "/login", component: Login },


### PR DESCRIPTION
# 🔀 Pull Request  

## 🔍 Summary  
Add full course browsing functionality for students, including course list, course details, and topic details views. Enables navigation between related data (e.g. course → topics, topic → course).

## 🔄 Changes Included  
- 🚀 **Add**  
  - `CourseList.vue` component for displaying courses using PrimeVue Cards  
  - `CourseDetails.vue` page to show full course info with topic list  
  - `TopicDetails.vue` page to show topic details including summary, key points, and resources  
- 🔄 **Update**  
  - `TopicList.vue` to route to `TopicDetails.vue`  
  - `Courses.vue` to integrate the new course list  
  - `DefaultLayout.vue` and `main.ts` to register and route new pages  
  - `router/index.ts` with new routes for course and topic details  

## ✅ Benefits  
- Improve **navigation between topics and courses**  
- Optimize **course and topic discoverability for students**  
- Reduce **manual linking and disconnected views**  

## 📌 Additional Notes  
- Courses and topics now support full view mode with route-based linking  
- Topic details route `/topics/:id` is now active  
- Course details route `/courses/:id` is now active  