### PR TITLE
✨ feat(login): add login modal handling and navigation menu integration

### DIFF
--- a/src/components/ui/NavigationMenu.vue
+++ b/src/components/ui/NavigationMenu.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+import { useAuthStore } from "../../stores/authStore";
+import { useCourse } from "../../stores/courseStore";
+import { useTopicStore } from "../../stores/topicStore";
+import { computed, onMounted, watchEffect } from "vue";
+import type { MenuItem } from "primevue/menuitem";
+import { storeToRefs } from "pinia";
+import { useModalStore } from '../../stores/modalStore';
+const modalStore = useModalStore();
+
+const router = useRouter();
+const props = defineProps<{
+  type: "default" | "admin";
+}>();
+
+const authStore = useAuthStore();
+const { isAuthenticated, username, role, user, token } = storeToRefs(authStore);
+const { fetchCurrentUser, logOut } = authStore;
+const courseStore = useCourse();
+const topicStore = useTopicStore();
+
+// Fetch courses and topics when needed
+onMounted(() => {
+  if (props.type === "default") {
+    courseStore.fetchCourses();
+    topicStore.fetchTopics();
+  }
+});
+
+// For admin login checks
+watchEffect(async () => {
+  if (props.type === "admin") {
+    if (!user.value && token.value) {
+      await fetchCurrentUser();
+    }
+    if (user.value && user.value.role !== "admin") {
+      console.log("⛔ Access Denied: Redirecting Non-Admin User");
+      router.push("/");
+    }
+  }
+});
+
+const logout = () => {
+  logOut();
+  if (props.type === "admin") {
+    router.push("/");
+  }
+};
+
+const items = computed<MenuItem[]>(() => {
+  if (props.type === "admin") {
+    return [
+      { label: "Home", icon: "pi pi-home", command: () => router.push("/") },
+      {
+        label: "Dashboard",
+        icon: "pi pi-th-large",
+        items: [
+          {
+            label: "Manage Quizzes",
+            icon: "pi pi-question-circle",
+            command: () => router.push("/admin/quizzes"),
+          },
+          {
+            label: "Manage Topics",
+            icon: "pi pi-list",
+            command: () => router.push("/admin/topics"),
+          },
+          {
+            label: "Manage Courses",
+            icon: "pi pi-briefcase",
+            command: () => router.push("/admin/courses"),
+          },
+          {
+            label: "Manage Users",
+            icon: "pi pi-users",
+            command: () => router.push("/admin/users"),
+          },
+        ],
+      },
+      // { label: "Quizzes", icon: "pi pi-book", command: () => router.push("/admin/quizzes") },
+      // { label: "Topics", icon: "pi pi-list", command: () => router.push("/admin/topics") },
+      // { label: "Courses", icon: "pi pi-briefcase", command: () => router.push("/admin/courses") },
+      // { label: "Users", icon: "pi pi-users", command: () => router.push("/admin/users") },
+    ];
+  } else {
+    return [
+      { label: "Home", icon: "pi pi-home", command: () => router.push("/") },
+      {
+        label: "Courses",
+        icon: "pi pi-book",
+        items: courseStore.courses.map((course) => ({
+          label: course.title,
+          items: (course.topics || []).map((topicId) => ({
+            label: topicStore.getTopicTitleById(topicId),
+            command: () => router.push(`/topics/${topicId}`),
+          })),
+        })),
+      },
+      {
+        label: "Quizzes",
+        icon: "pi pi-question-circle",
+        command: () => router.push("/quizzes"),
+      },
+      {
+        label: "Topics",
+        icon: "pi pi-th-large",
+        command: () => router.push("/topics"),
+      },
+      {
+        label: "Admin",
+        icon: "pi pi-cog",
+        command: () => router.push("/admin"),
+        visible: authStore.isAdmin,
+      },
+    ];
+  }
+});
+</script>
+
+<template>
+  <nav
+    class="bg-gray-100 dark:bg-gray-800 p-2 space-y-4 min-w-80 flex flex-col items-start rounded"
+  >
+    <div v-if="isAuthenticated" class="capitalize">
+      <span class="pi pi-user pr-2"></span>
+      {{ username }}
+      <p class="flex flex-col italic">{{ role }}</p>
+    </div>
+    <Button
+      v-else
+      icon="pi pi-user"
+      label="Login"
+      @click="modalStore.showLoginModal = true"
+      class="p-2"
+      fluid
+    />
+    <PanelMenu
+      :model="items"
+      class="bg-gray-200 text-white rounded-md shadow-md w-full"
+    >
+      <template #item="{ item }">
+        <a v-ripple class="flex items-center px-4 py-2 cursor-pointer group">
+          <span
+            :class="[item.icon, 'text-primary-50 group-hover:text-blue-300']"
+          />
+          <span :class="['ml-2', { 'font-semibold': item.items }]">{{
+            item.label
+          }}</span>
+          <span
+            v-if="item.items"
+            class="pi pi-angle-down text-primary ml-auto"
+          />
+        </a>
+      </template>
+    </PanelMenu>
+    <Button
+      v-if="isAuthenticated"
+      @click="logout"
+      icon="pi pi-sign-out"
+      class="p-2"
+      label="Logout"
+      fluid
+      severity="danger"
+    />
+  </nav>
+</template>

--- a/src/layouts/AdminLayout.vue
+++ b/src/layouts/AdminLayout.vue
@@ -1,104 +1,12 @@
 <script setup lang="ts">
-import { useRouter } from "vue-router";
-import { useAuthStore } from "../stores/authStore";
 import MessageToast from "../components/ui/MessageToast.vue";
-import type { MenuItem } from "primevue/menuitem";
-import { ref, watchEffect } from "vue";
+import NavigationMenu from "../components/ui/NavigationMenu.vue";
 
-const router = useRouter();
-const authStore = useAuthStore();
-
-watchEffect(async () => {
-  if (!authStore.user && authStore.token) {
-    await authStore.fetchCurrentUser();
-  }
-  
-  // Only check role after user is fetched
-  if (authStore.user) {
-    if (authStore.user.role !== 'admin') {
-      console.warn("⛔ Access Denied: Redirecting Non-Admin User");
-      router.push("/");
-    }
-  }
-});
-
-// ✅ Logout Function
-const logout = () => {
-  authStore.logOut();
-};
-
-const items = ref<MenuItem[]>([
-  {
-    label: "Home",
-    icon: "pi pi-home",
-    command: () => router.push("/"),
-  },
-  {
-    label: "Dashboard",
-    icon: "pi pi-th-large",
-    command: () => router.push("/admin"),
-  },
-  {
-    label: "Quizzes",
-    icon: "pi pi-book",
-    command: () => router.push("/admin/quizzes"),
-  },
-  {
-    label: "Topics",
-    icon: "pi pi-list",
-    command: () => router.push("/admin/topics"),
-  },
-  {
-    label: "Courses",
-    icon: "pi pi-briefcase",
-    command: () => router.push("/admin/courses"),
-  },
-  {
-    label: "Users",
-    icon: "pi pi-users",
-    command: () => router.push("/admin/users"),
-  },
-]);
 </script>
 <template>
   <div class="flex flex-row-reverse w-full h-screen">
     <!-- Sidebar Navigation -->
-    <nav
-      class="flex flex-col justify-start items-baseline rounded bg-gray-100 dark:bg-gray-800 p-2 space-y-4 min-w-50"
-    >
-      <div v-if="authStore.isAuthenticated" class="capitalize">
-        <span class="pi pi-star pr-2"> </span>
-        {{ authStore.user?.username }}
-        <p class="flex flex-col">
-          <span class="italic">
-            {{ authStore.user?.role }}
-          </span>
-        </p>
-      </div>
-      <PanelMenu
-        :model="items"
-        class="bg-gray-200 text-white rounded-md shadow-md w-full"
-      >
-        <template #item="{ item }">
-          <a v-ripple class="flex items-center px-4 py-2 cursor-pointer group">
-            <span
-              :class="[item.icon, 'text-primary-50 group-hover:text-blue-300']"
-            />
-            <span :class="['ml-2', { 'font-semibold': item.items }]">{{
-              item.label
-            }}</span>
-          </a>
-        </template>
-      </PanelMenu>
-      <Button
-        icon="pi pi-sign-out"
-        label="Logout"
-        @click="logout"
-        severity="danger"
-        class="bg-red-100 hover:bg-red-300 text-gray-800 p-2 rounded-md"
-        fluid
-      />
-    </nav>
+    <NavigationMenu type="admin" />
 
     <!-- Main Content Area -->
     <main class="flex-1 p-6 bg-gray-100 overflow-auto">

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -1,99 +1,21 @@
 <script setup lang="ts">
-import { useAuthStore } from "../stores/authStore";
-import { useRouter } from "vue-router";
-import { ref, computed } from "vue";
+import { storeToRefs } from 'pinia';
+import { useModalStore } from '../stores/modalStore';
 import Login from "../components/ui/Login.vue";
-import type { MenuItem } from "primevue/menuitem";
+import NavigationMenu from "../components/ui/NavigationMenu.vue";
 
-const authStore = useAuthStore();
-const router = useRouter();
-const showLoginModal = ref(false);
-
-const handleLogout = () => {
-  authStore.logOut();
-  router.push("/");
-};
-
-const items = computed<MenuItem[]>(() => [
-  {
-    label: "Home",
-    icon: "pi pi-home",
-    command: () => router.push("/"),
-  },
-  {
-    label: "Courses",
-    icon: "pi pi-book",
-    command: () => router.push("/courses"),
-  },
-  {
-    label: "Quizzes",
-    icon: "pi pi-question-circle",
-    command: () => router.push("/quizzes"),
-  },
-  {
-    label: "Topics",
-    icon: "pi pi-th-large",
-    command: () => router.push("/topics"),
-  },
-  {
-    label: "Admin",
-    icon: "pi pi-cog",
-    command: () => router.push("/admin"),
-    visible: authStore.isAdmin,
-  },
-]);
+const modalStore = useModalStore();
+const { showLoginModal } = storeToRefs(modalStore);
 </script>
 
 <template>
   <div class="flex flex-row-reverse w-full h-screen bg-gray-50 overflow-auto">
-    <nav class="bg-gray-100 dark:bg-gray-800 p-2 space-y-4 min-w-50">
-      <div class="mb-4">
-        <div v-if="authStore.isAuthenticated" class="capitalize">
-          <span class="pi pi-graduation-cap pr-2"> </span>
-          {{ authStore.user?.username }}
-          <p class="flex flex-col">
-            <span class="italic">
-              {{ authStore.user?.role }}
-            </span>
-          </p>
-        </div>
-        <Button
-          icon="pi pi-user"
-          label="Login"
-          v-else
-          @click="showLoginModal = true"
-          fluid
-        >
-        </Button>
-      </div>
-      <PanelMenu
-        :model="items"
-        class="bg-gray-200 text-white rounded-md shadow-md w-full"
-      >
-        <template #item="{ item }">
-          <a v-ripple class="flex items-center px-4 py-2 cursor-pointer group">
-            <span
-              :class="[item.icon, 'text-primary-50 group-hover:text-blue-300']"
-            />
-            <span :class="['ml-2', { 'font-semibold': item.items }]">{{
-              item.label
-            }}</span>
-          </a>
-        </template>
-      </PanelMenu>
-      <Button
-        v-if="authStore.isAuthenticated"
-        @click="handleLogout"
-        icon="pi pi-sign-out"
-        class="p-2"
-        label="Logout"
-        fluid
-        severity="danger"
-      />
-    </nav>
+    <!-- Handle open-login from NavigationMenu to control showLoginModal -->
+    <NavigationMenu type="default" @open-login="showLoginModal = true" />
     <main class="w-full flex">
       <router-view />
     </main>
-    <Login v-model:visible="showLoginModal" />
+    <!-- Pass showLoginModal to Login.vue to manage its visibility -->
+    <Login v-model:visible="showLoginModal" key="login-modal" />
   </div>
 </template>

--- a/src/pages/Home.vue
+++ b/src/pages/Home.vue
@@ -6,7 +6,7 @@ import { useAuthStore } from '../stores/authStore';
 const authStore = useAuthStore();
 </script>
 <template>
-  <div class="p-6 bg-gray-50 dark:bg-gray-700 w-full">
+  <div class="p-6 bg-gray-50 dark:bg-gray-500 w-full">
     <h1 class="text-2xl font-bold">Welcome to ThinkAPIc</h1>
     <p class="text-gray-600">
       Prepare for your web development exams
@@ -21,4 +21,5 @@ const authStore = useAuthStore();
       Please log in to see your progress and available courses.
     </div>
   </div>
+  
 </template>

--- a/src/pages/TopicDetails.vue
+++ b/src/pages/TopicDetails.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, watch } from "vue";
 import { useRoute } from "vue-router";
 
 import type { Topic } from "../types/Topic";
@@ -14,9 +14,22 @@ const openQuizDialog = () => {
   showQuizDialog.value = true;
 };
 
-onMounted(async () => {
-  const id = route.params.id as string;
+const fetchTopicDetails = async (id: string) => {
   topic.value = await getTopicById(id);
+};
+
+watch(
+  () => route.params.id,
+  async (newId) => {
+    if (newId) {
+      topic.value = await getTopicById(newId as string);
+    }
+  }
+);
+
+onMounted(() => {
+  const id = route.params.id as string;
+  fetchTopicDetails(id);
 });
 </script>
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -31,15 +31,15 @@ api.interceptors.request.use((config) => {
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    const authStore = useAuthStore();
-
     if (error.response) {
       console.error('API Error:', error.response.status, error.response.data);
 
-      // If token expired, logout user
-      if (error.response.status === 401) {
+      const isLoginRequest = error.config?.url?.includes('/auth/login');
+
+      if (error.response.status === 401 && !isLoginRequest) {
+        const authStore = useAuthStore();
         authStore.logOut();
-        window.location.href = '/'; 
+        window.location.href = '/';
       }
     } else {
       console.error('Network/Server Error:', error);

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -4,10 +4,12 @@ export const login = (email: string, password: string) => {
   return api.post('/auth/login', { email, password });
 };
 
+export const register = async (username: string, email: string, password: string, role: string = "student") => {
+  const response = await api.post("/auth/register", { username, email, password, role });
+  return response.data; // Ensure this is returning the user object
+};
+
 export const getCurrentUser = async () => {
   return api.get('/auth/me'); 
 };
 
-export const logout = () => {
-  localStorage.removeItem('token');
-};

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -1,0 +1,7 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
+export const useModalStore = defineStore('modal', () => {
+  const showLoginModal = ref(false);
+  return { showLoginModal };
+});


### PR DESCRIPTION
# 🔀 Pull Request  

## 🔍 Summary  
Adds login modal logic and improves navigation + route protection UX.

## 🔄 Changes Included  
- 🚀 **Add**  
  - `NavigationMenu.vue` with login button  
  - `modalStore.ts` to manage login dialog visibility  

- 🛠 **Refactor**  
  - `Login.vue` to keep dialog open on failed login  
  - `authStore.ts` and `authService.ts` to return structured login responses  

- 🔄 **Update**  
  - `router/index.ts` to open login modal for `requiresAuth` routes  
  - `DefaultLayout.vue` and `AdminLayout.vue` for new navigation logic  
  - `Home.vue` and `TopicDetails.vue` layout structure  

- ⚡ **Optimize**  
  - UX for login and route redirection logic  

- 🐛 **Fix**  
  - Prevent modal from closing on login error  
  - Avoid token assignment on failed login  

## ✅ Benefits  
- Improve **authentication flow and user feedback**  
- Optimize **navigation clarity and modal behavior**  
- Reduce **unexpected dialog closure and manual UI control**  

## 📌 Additional Notes  
- No `/login` route is used — modal handles login from any page.  
- `modalStore` is now the source of truth for login dialog visibility.  