### PR TITLE
🔧 refactor(topic): clean up types, extract helpers, simplify logic

### DIFF
--- a/src/components/admin/ManageCourseForm.vue
+++ b/src/components/admin/ManageCourseForm.vue
@@ -10,7 +10,7 @@ import type { AdminUser } from "../../types/User";
 const courseStore = useCourseStore();
 const topicStore = useTopicStore();
 
-const { draftCourse, successMessage, errorMessage, isEditing, showTopicForm } =
+const { draftCourse, successMessage, isEditing, showTopicForm } =
   storeToRefs(courseStore);
 const { resetCourseDraft, submitDraftCourse } = courseStore;
 
@@ -43,16 +43,19 @@ const formSections = [
     label: "Learning Objectives",
     list: () => ref(draftCourse.value.learningObjectives),
     model: newLearningObjective,
+    inputLabel: "New Objective",
   },
   {
     label: "Skills",
     list: () => ref(draftCourse.value.skills),
     model: newSkill,
+    inputLabel: "New Skill",
   },
   {
     label: "Competencies",
     list: () => ref(draftCourse.value.competencies),
     model: newCompetency,
+    inputLabel: "New Competency",
   },
 ];
 
@@ -120,7 +123,7 @@ const handleSubmit = async () => {
 
     // Reset the form
     resetCourseDraft();
-    
+
     nextTick(() => {
       showTopicForm.value = true;
     });
@@ -145,7 +148,8 @@ const closeForm = () => {
     v-model:visible="props.visible"
     @update:visible="(value) => emit('update:visible', value)"
     modal
-    class="w-full p-4 overflow-auto"
+    style="max-height: none"
+    class="w-full px-2 md:px-10 overflow-auto h-svh py-10"
     :pt="{
       root: { class: '!border-0 !bg-transparent' },
       mask: { class: 'backdrop-blur-sm' },
@@ -153,21 +157,17 @@ const closeForm = () => {
   >
     <template #container="{ closeCallback }">
       <div
-        class="flex flex-col px-8 py-8 gap-6 rounded-2xl"
+        class="flex flex-col p-4 md:p-8 gap-4 rounded-2xl"
         style="
           background-image: radial-gradient(
-            circle at left top,
+            circle at center center,
             var(--p-primary-400),
-            var(--p-primary-700)
+            var(--p-primary-300)
           );
         "
       >
-        <img
-          src="/ExplodingHead.svg"
-          alt="Exploding Head"
-          class="w-10 h-10 mx-auto"
-        />
-        <h1 class="text-2xl font-bold mb-4">
+        <h1 class="text-3xl font-bold mb-4">
+          <i class="pi pi-thumbtack"> </i>
           {{ isEditing ? "Edit Course" : "Add New Course" }}
         </h1>
 
@@ -186,7 +186,7 @@ const closeForm = () => {
         <FloatLabel variant="on">
           <Textarea
             id="course_description"
-            class="border w-full mb-4"
+            class="border w-full"
             v-model="draftCourse.description"
             rows="5"
             cols="30"
@@ -243,9 +243,9 @@ const closeForm = () => {
             <li
               v-for="(topicId, index) in draftCourse.topics"
               :key="topicId"
-              class="flex items-center justify-between"
+              class="flex items-center justify-between bg-gray-100 mb-2 shadow p-2 rounded-md"
             >
-              <span>
+              <span class="capitalize font-bold">
                 -
                 {{
                   topics.find((t) => t._id === topicId)?.title ||
@@ -256,7 +256,6 @@ const closeForm = () => {
                 type="button"
                 severity="danger"
                 icon="pi pi-times"
-                class="text-red-500 text-sm"
                 @click="draftCourse.topics.splice(index, 1)"
               />
             </li>
@@ -265,30 +264,33 @@ const closeForm = () => {
             type="button"
             label="Add Topic"
             icon="pi pi-plus"
-            class="bg-blue-500 text-white px-2 py-1 rounded mb-4"
             @click="emit('update:showTopicForm', true)"
           />
         </div>
 
         <!-- Reusable Inputs for Learning Objectives, Skills, and Competencies -->
-        <div v-for="section in formSections" :key="section.label">
-          <label class="block font-bold mb-2">{{ section.label }}</label>
+        <div class v-for="section in formSections" :key="section.label">
+          <label class="block font-bold mb-4">{{ section.label }}</label>
 
           <div
             v-for="(item, index) in section.list().value"
             :key="index"
-            class="flex items-center mb-2 shadow p-2 rounded"
+            class="bg-gray-100 flex mb-2 shadow p-2 rounded-md"
           >
-            <span class="flex-grow">{{ item }}</span>
+            <div class="overflow-auto w-full shadow flex items-center scroll-smooth rounded-md mb-2 p-2">
+              <span class="flex-grow capitalize font-bold w-full">{{
+                item
+              }}</span>
 
-            <Button
-              type="button"
-              icon="pi pi-times"
-              severity="danger"
-              @click="removeItem(section.list(), index)"
-              class="text-red-500 ml-2"
-            />
+              <Button
+                type="button"
+                icon="pi pi-times"
+                severity="danger"
+                @click="removeItem(section.list(), index)"
+              />
+            </div>
           </div>
+
           <div class="form-section flex gap-2">
             <FloatLabel variant="on" class="flex-grow">
               <InputText
@@ -297,39 +299,37 @@ const closeForm = () => {
                 type="text"
                 class="border p-2 w-full"
               />
-              <label :for="'new_' + section.label">{{ section.label }}</label>
+              <label :for="'new_' + section.label">{{
+                section.inputLabel
+              }}</label>
             </FloatLabel>
 
             <Button
               type="button"
               icon="pi pi-arrow-up"
-              :label="section.label"
+              label="Add"
               @click="addItem(section.list(), section.model)"
-              class="bg-blue-500 text-white px-2 py-1 rounded-md"
             />
           </div>
         </div>
 
-        <!-- Error message -->
-        <p v-if="errorMessage" class="text-red-200 text-sm mt-2">
-          {{ errorMessage }}
-        </p>
-
         <div class="flex items-center gap-4">
           <Button
             label="Cancel"
+            icon="pi pi-times"
             @click="
               closeCallback;
               closeForm();
             "
             text
-            class="!p-2 w-full !text-slate-300 !border !border-white/30 hover:!bg-white/10"
+            class="!p-2 w-full !text-gray-600 !border !border-red-600/30 hover:!bg-red-700/10 hover:!text-gray-50"
           />
           <Button
-            label="Submit Course"
+            label="Submit"
+            icon="pi pi-check"
             @click="handleSubmit"
             text
-            class="!p-2 w-full !text-slate-300 !border !border-white/30 hover:!bg-white/10"
+            class="!p-2 w-full !text-gray-600 !border !border-green-600/30 hover:!bg-green-700/10 hover:!text-gray-50"
           />
         </div>
       </div>

--- a/src/components/admin/ManageTopicForm.vue
+++ b/src/components/admin/ManageTopicForm.vue
@@ -237,7 +237,8 @@ onMounted(async () => {
     v-model:visible="props.visible"
     @update:visible="(val) => emit('update:visible', val)"
     modal
-    class="px-4 overflow-auto"
+    style="max-height: none"
+    class="w-full px-2 md:px-14 h-svh overflow-auto py-10"
     :pt="{
       root: { class: '!border-0 !bg-transparent' },
       mask: { class: 'backdrop-blur-sm' },
@@ -245,25 +246,22 @@ onMounted(async () => {
   >
     <template #container="{ closeCallback }">
       <div
-        class="flex flex-col p-6 gap-6 rounded-2xl"
+        class="flex flex-col p-4 md:p-8 gap-4 rounded-2xl"
         style="
           background-image: radial-gradient(
-            circle at left top,
-            var(--p-primary-400),
-            var(--p-primary-700)
+            circle at center center,
+            var(--p-primary-300),
+            var(--p-primary-200)
           );
         "
       >
         <Toast />
-        <h1 class="text-2xl font-bold text-primary-100">
+        <h1 class="text-2xl font-bold">
           <i class="pi pi-thumbtack text-4xl"> </i>
           {{ isEditing ? "Edit Topic" : "Add New Topic" }}
         </h1>
 
-        <form
-          @submit.prevent="submitTopic"
-          class="p-2 shadow-md space-y-4 rounded-md"
-        >
+        <form @submit.prevent="submitTopic" class="space-y-4 rounded-md">
           <!-- Course form fields -->
           <FloatLabel variant="on">
             <InputText v-model="title" label="Topic Title" fluid />
@@ -279,6 +277,7 @@ onMounted(async () => {
               :min="1"
               :max="18"
               fluid
+              :inputStyle="{ padding: '0.5rem' }"
             />
             <label for="minmax-buttons" class="block">Week</label>
           </FloatLabel>
@@ -300,6 +299,7 @@ onMounted(async () => {
               inputId="course_select"
               :options="courseStore.courses"
               optionLabel="title"
+              placeholder="Select a Course"
               fluid
             />
           </FloatLabel>
@@ -334,7 +334,7 @@ onMounted(async () => {
             />
           </div>
 
-          <div class="flex gap-2">
+          <div class="flex flex-col md:flex-row gap-2">
             <FloatLabel variant="on" class="flex-grow">
               <InputText
                 v-model="newKeyPoint"
@@ -349,7 +349,7 @@ onMounted(async () => {
               @click="addKeyPoint"
               class="min-w-32"
               icon="pi pi-plus"
-              label="Add Key Point"
+              label="Add"
             />
           </div>
 
@@ -358,7 +358,7 @@ onMounted(async () => {
           <div
             v-for="(resource, index) in resources"
             :key="index"
-            class="flex items-center p-2 gap-2 bg-gray-100 dark:bg-gray-950 rounded-md"
+            class="flex flex-col md:flex-row items-center p-2 gap-2 bg-gray-100 dark:bg-gray-950 rounded-md"
           >
             <span v-if="!isEditingResource(index)" class="flex-grow">
               {{ resource.title }} -
@@ -366,7 +366,7 @@ onMounted(async () => {
                 resource.link
               }}</a>
             </span>
-            <div v-else class="flex w-full gap-2">
+            <div v-else class=" w-full gap-2">
               <InputText
                 v-model="resources[index].title"
                 label="Resource Title"
@@ -384,22 +384,26 @@ onMounted(async () => {
                 />
               </IconField>
             </div>
-            <Button
-              type="button"
-              @click="toggleEditingResource(index)"
-              :severity="getButtonState(index, true).severity"
-              :icon="getButtonState(index, true).icon"
-            />
-            <Button
-              type="button"
-              @click="removeResource(index)"
-              severity="danger"
-              icon="pi pi-times"
-            />
+            
+              <Button
+                type="button"
+                @click="toggleEditingResource(index)"
+                :severity="getButtonState(index, true).severity"
+                :icon="getButtonState(index, true).icon"
+              />
+              <Button
+                type="button"
+                @click="removeResource(index)"
+                severity="danger"
+                icon="pi pi-times"
+              />
+            
           </div>
 
-          <div class="resources flex w-full space-x-2">
-            <FloatLabel variant="on" class="w-1/3">
+          <div
+            class="resources flex flex-col md:flex-row w-full space-y-2 md:space-y-0 md:space-x-2"
+          >
+            <FloatLabel variant="on" class="w-full md:w-1/3">
               <InputText
                 v-model="newResource.title"
                 label="Resource Title"
@@ -407,7 +411,7 @@ onMounted(async () => {
               />
               <label for="resource_title" class="block mb-2">Title</label>
             </FloatLabel>
-            <FloatLabel variant="on" class="flex-grow">
+            <FloatLabel variant="on" class="w-full md:w-2/3">
               <IconField class="">
                 <InputIcon icon="pi pi-link " class="pi pi-link" />
                 <InputText v-model="newResource.link" label="Link" fluid />
@@ -417,34 +421,30 @@ onMounted(async () => {
             <Button
               type="button"
               @click="addResource"
-              label="Add Resource"
+              label="Add"
               class="min-w-32"
               icon="pi pi-plus"
             />
           </div>
 
-          <div class="button-group flex justify-end space-x-2">
-            <Button
-              :label="isEditing ? 'Update Topic' : 'Submit Topic'"
-              icon="pi pi-check"
-              type="submit"
-              severity="success"
-            />
+          <div class="button-group flex items-center gap-4">
             <Button
               type="button"
               label="Cancel"
-              severity="secondary"
               icon="pi pi-times"
               @click="
                 closeCallback;
                 closeForm();
               "
+              class="!p-2 w-full !text-gray-600 !bg-transparent !border !border-red-600/30 hover:!bg-red-700/10 hover:!text-gray-50"
+            />
+            <Button
+              :label="isEditing ? 'Update' : 'Submit'"
+              icon="pi pi-check"
+              type="submit"
+              class="!p-2 w-full !text-gray-600 !bg-transparent !border !border-green-600/30 hover:!bg-green-700/10 hover:!text-gray-50"
             />
           </div>
-
-          <p v-if="errorMessage" class="text-red-500 mt-4">
-            {{ errorMessage }}
-          </p>
         </form>
       </div>
     </template>

--- a/src/components/quizzes/TopicQuizzes.vue
+++ b/src/components/quizzes/TopicQuizzes.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted, computed, watch } from "vue";
 import { storeToRefs } from "pinia";
 import { useProgressStore } from "../../stores/progressStore";
 import { useQuizStore } from "../../stores/quizStore";
@@ -49,6 +49,18 @@ onMounted(async () => {
   }
 });
 
+watch(
+  () => quizzes.value,
+  (newQuizzes) => {
+    newQuizzes.forEach((q) => {
+      if (!(q._id in selectedOptions.value)) {
+        selectedOptions.value[q._id] = undefined;
+      }
+    });
+  },
+  { immediate: true }
+);
+
 const closeDialog = (value: boolean) => {
   emit("update:visible", value);
   if (value === false && authStore.user) {
@@ -79,9 +91,7 @@ const submitAll = async () => {
 };
 
 const hasUnansweredQuestions = () => {
-  return quizzes.value.some(
-    (q) => selectedOptions.value[q._id] == null
-  );
+  return quizzes.value.some((q) => selectedOptions.value[q._id] == null);
 };
 
 const submitQuizzesAndHandleProgress = async () => {

--- a/src/helpers/topicHelpers.ts
+++ b/src/helpers/topicHelpers.ts
@@ -1,0 +1,70 @@
+import { createTopic, updateTopicById } from "../services/topicService";
+import type { Course } from "../types/Course";
+import type { Topic, TopicInput } from "../types/Topic";
+import type { UpdateTopicInput, NewTopicInput } from "../types/Topic";
+
+export const resetMessages = (
+  successMessage: { value: string },
+  errorMessage: { value: string }
+) => {
+  successMessage.value = "";
+  errorMessage.value = "";
+};
+
+export const getSuccessMessage = (isEditing: boolean): string =>
+  isEditing ? "Topic updated successfully!" : "Topic added successfully!";
+
+export const handleError = (
+  error: any,
+  errorMessage: { value: string }
+): void => {
+  errorMessage.value =
+    error?.response?.data?.error || "Something went wrong. Please try again.";
+};
+
+export const validateForm = (data: {
+  title: string;
+  week: number | null;
+  summary: string;
+  course: Course | null;
+}): boolean => {
+  return Boolean(
+    data.title &&
+      data.week !== null &&
+      !isNaN(Number(data.week)) &&
+      data.summary &&
+      data.course
+  );
+};
+
+export const buildTopicInput = (data: {
+  title: string;
+  week: number | null;
+  summary: string;
+  courseId: string;
+  keyPoints: string[];
+  resources: { title: string; link: string }[];
+}): TopicInput => ({
+  title: data.title,
+  week: data.week ?? 1,
+  summary: data.summary,
+  course: data.courseId,
+  key_points: data.keyPoints,
+  resources: data.resources.map((r) => ({ ...r, _id: "" })),
+});
+export const getCourseId = (course: string | Course): string => {
+  return typeof course === "string" ? course : course._id;
+};
+
+export const createTopicHelper = async (
+  data: NewTopicInput
+): Promise<Topic> => {
+  return await createTopic(data);
+};
+
+export const updateTopicHelper = async (
+  id: string,
+  data: UpdateTopicInput
+): Promise<Topic> => {
+  return await updateTopicById(id, data);
+};

--- a/src/services/topicService.ts
+++ b/src/services/topicService.ts
@@ -1,26 +1,29 @@
-import type { Topic } from '../types/Topic';
-import api from './api';
+import type { NewTopicInput, Topic, UpdateTopicInput } from "../types/Topic";
+import api from "./api";
 
 export const getTopics = async (): Promise<Topic[]> => {
-    const { data } = await api.get<Topic[]>('/topics');
-    return data;
+  const { data } = await api.get<Topic[]>("/topics");
+  return data;
 };
 
 export const getTopicById = async (id: string): Promise<Topic> => {
-    const { data } = await api.get<Topic>(`/topics/${id}`);
-    return data;
+  const { data } = await api.get<Topic>(`/topics/${id}`);
+  return data;
 };
 
-export const createTopic = async (topic: Omit<Topic, '_id'>): Promise<Topic> => {
-    const { data } = await api.post<Topic>('/topics', topic);
-    return data;
+export const createTopic = async (topic: NewTopicInput): Promise<Topic> => {
+  const { data } = await api.post<Topic>("/topics", topic);
+  return data;
 };
 
-export const updateTopicById = async (id: string, topic: Partial<Topic>): Promise<Topic> => {
-    const { data } = await api.put<Topic>(`/topics/${id}`, topic);
-    return data;
+export const updateTopicById = async (
+  id: string,
+  topic: UpdateTopicInput
+): Promise<Topic> => {
+  const { data } = await api.put<Topic>(`/topics/${id}`, topic);
+  return data;
 };
 
 export const deleteTopicById = async (id: string): Promise<void> => {
-    await api.delete(`/topics/${id}`);
+  await api.delete(`/topics/${id}`);
 };

--- a/src/stores/courseStore.ts
+++ b/src/stores/courseStore.ts
@@ -80,6 +80,10 @@ export const useCourseStore = defineStore("courses", () => {
       courses.value = courses.value.filter((course) => course._id !== id);
     });
 
+  const findCourseById = (id: string): Course | undefined => {
+    return courses.value.find((course) => course._id === id);
+  };
+
   // UI state helpers
   const editCourse = (course: Course) => {
     selectedCourse.value = { ...course };
@@ -194,6 +198,7 @@ export const useCourseStore = defineStore("courses", () => {
     error,
     errorMessage,
     fetchCourses,
+    findCourseById,
     handleCourseUpdated,
     isEditing,
     loading,

--- a/src/stores/topicStore.ts
+++ b/src/stores/topicStore.ts
@@ -8,96 +8,88 @@ import {
   updateTopicById,
   deleteTopicById,
 } from "../services/topicService";
-import type { Topic, TopicInput } from "../types/Topic";
+import type {
+  NewTopicInput,
+  Topic,
+  TopicInput,
+  UpdateTopicInput,
+} from "../types/Topic";
 import type { Course } from "../types/Course";
 import { useCourseStore } from "../stores/courseStore";
+import {
+  createTopicHelper,
+  getCourseId,
+  updateTopicHelper,
+} from "../helpers/topicHelpers";
 
 export const useTopicStore = defineStore("topics", () => {
+  // State and store setup
   const topics = ref<Topic[]>([]);
   const loading = ref<boolean>(false);
   const error = ref<string | null>(null);
-  const courseStore = useCourseStore();
 
-  // 🔹 Fetch all topics
+  const courseStore = useCourseStore();
+  const { findCourseById } = courseStore;
+
+  // Topic CRUD operations
   const fetchTopics = async () => {
     loading.value = true;
     try {
       topics.value = await getTopics();
     } catch (err) {
-      //console.error("❌ Error fetching topics:", err);
       error.value = "Failed to load topics.";
     } finally {
       loading.value = false;
     }
   };
 
-  // 🔹 Fetch a single topic by ID
   const fetchTopicById = async (id: string) => {
     loading.value = true;
     try {
       const topic = await getTopicById(id);
-      if (!topics.value.some((t) => t._id === id)) {
-        topics.value.push(topic);
-      }
+      addToTopicsIfMissing(topic);
       return topic;
     } catch (err) {
-      //console.error("❌ Error fetching topic:", err);
       error.value = "Failed to load topic.";
     } finally {
       loading.value = false;
     }
   };
 
-  // 🔹 Add a new topic
-  const addTopic = async (newTopic: Omit<Topic, "_id">) => {
+  const addTopic = async (newTopic: NewTopicInput) => {
     loading.value = true;
     try {
       const createdTopic = await createTopic(newTopic);
       topics.value.push(createdTopic);
     } catch (err) {
-      //console.error("❌ Error adding topic:", err);
       error.value = "Failed to add topic.";
     } finally {
       loading.value = false;
     }
   };
 
-  // 🔹 Update an existing topic
-  const updateTopic = async (updatedTopic: Topic) => {
+  const updateTopic = async (updatedTopic: UpdateTopicInput) => {
     loading.value = true;
     try {
       const response = await updateTopicById(updatedTopic._id, updatedTopic);
       const index = topics.value.findIndex((t) => t._id === updatedTopic._id);
       if (index !== -1) topics.value[index] = response;
     } catch (err) {
-      //console.error("❌ Error updating topic:", err);
       error.value = "Failed to update topic.";
     } finally {
       loading.value = false;
     }
   };
 
-  // Combined create or update function
   const saveTopic = async (
-    topicData: Partial<TopicInput>,
+    topicData: TopicInput,
     topicId?: string
   ): Promise<Topic> => {
     loading.value = true;
     try {
-      if (topicId) {
-        const updatedTopic = {
-          ...(topicData as TopicInput),
-          _id: topicId,
-        };
-        const result = await updateTopicById(topicId, updatedTopic as unknown as Partial<Topic>);
-        const index = topics.value.findIndex((t) => t._id === topicId);
-        if (index !== -1) topics.value[index] = result;
-        return result;
-      } else {
-        const createdTopic = await createTopic(topicData as unknown as Omit<Topic, '_id'>);
-        topics.value.push(createdTopic);
-        return createdTopic;
-      }
+      return topicId
+        ? await updateTopicHelper(topicId, { ...topicData, _id: topicId })
+        : await createTopicHelper(topicData);
     } catch (err) {
       error.value = "Failed to save topic.";
       throw err;
@@ -106,7 +98,6 @@ export const useTopicStore = defineStore("topics", () => {
     }
   };
 
-  // 🔹 Delete a topic
   const deleteTopic = async (id: string) => {
     loading.value = true;
     try {
@@ -115,13 +106,56 @@ export const useTopicStore = defineStore("topics", () => {
 
       topics.value = topics.value.filter((topic) => topic._id !== id);
     } catch (err) {
-      //console.error("❌ Error deleting topic:", err);
       error.value = "Failed to delete topic.";
     } finally {
       loading.value = false;
     }
   };
 
+  // Topic-course relationship handlers
+  const handleTopicCreated = (newTopic: Topic) => {
+    addToTopicsIfMissing(newTopic);
+    syncTopicWithCourse(newTopic);
+    updateSelectedCourseIfNeeded(newTopic);
+    closeTopicForm();
+  };
+
+  const addToTopicsIfMissing = (topic: Topic) => {
+    if (!topics.value.some((t) => t._id === topic._id)) {
+      topics.value.push(topic);
+    }
+  };
+
+  const syncTopicWithCourse = (topic: Topic) => {
+    const courseId = getCourseId(topic.course);
+    const course = findCourseById(courseId);
+    if (course) addTopicToCourseIfMissing(course, topic._id);
+  };
+
+  const addTopicToCourseIfMissing = (course: Course, topicId: string) => {
+    if (!course.topics.includes(topicId)) {
+      course.topics.push(topicId);
+    }
+  };
+
+  const updateSelectedCourseIfNeeded = (topic: Topic) => {
+    const courseId = getCourseId(topic.course);
+    const { selectedCourse } = storeToRefs(courseStore);
+
+    if (selectedCourse.value && selectedCourse.value._id === courseId) {
+      selectedCourse.value = {
+        ...selectedCourse.value,
+        topics: [...selectedCourse.value.topics, topic._id],
+      };
+    }
+  };
+
+  const closeTopicForm = () => {
+    const { showTopicForm } = storeToRefs(courseStore);
+    showTopicForm.value = false;
+  };
+
+  // Utility functions
   const removeTopicFromCourses = (topicId: string) => {
     // Loop through all courses and remove the topic from the topics array
     courseStore.courses.forEach((course: Course) => {
@@ -133,14 +167,14 @@ export const useTopicStore = defineStore("topics", () => {
     });
   };
 
-  // 🔹 Get topic title by ID
+  // Computed properties
   const getTopicTitleById = computed(() => (id: string) => {
     return (
       topics.value.find((topic) => topic._id === id)?.title || "Unknown Topic"
     );
   });
 
-  // 🔹 Validate a topic object
+  // Validation functions
   const isTopicValid = (topic: Partial<Topic>): boolean => {
     return Boolean(
       topic.title &&
@@ -151,36 +185,6 @@ export const useTopicStore = defineStore("topics", () => {
     );
   };
 
-  const handleTopicCreated = (newTopic: Topic) => {
-    if (!topics.value.some((t: Topic) => t._id === newTopic._id)) {
-      topics.value.push(newTopic);
-    }
-
-    const courseId =
-      typeof newTopic.course === "string"
-        ? newTopic.course
-        : newTopic.course._id;
-
-    const course = courseStore.courses.find((c) => c._id === courseId);
-
-    if (course && Array.isArray(course.topics)) {
-      if (!course.topics.includes(newTopic._id)) {
-        course.topics.push(newTopic._id);
-      }
-    }
-
-    const { selectedCourse, showTopicForm } = storeToRefs(courseStore);
-
-    if (selectedCourse.value && selectedCourse.value._id === courseId) {
-      selectedCourse.value = {
-        ...selectedCourse.value,
-        topics: [...selectedCourse.value.topics, newTopic._id],
-      };
-    }
-
-    showTopicForm.value = false;
-  };
-
   return {
     topics,
     loading,
@@ -189,9 +193,9 @@ export const useTopicStore = defineStore("topics", () => {
     fetchTopicById,
     addTopic,
     updateTopic,
+    saveTopic,
     deleteTopic,
     getTopicTitleById,
-    saveTopic,
     isTopicValid,
     handleTopicCreated,
   };

--- a/src/types/Topic.ts
+++ b/src/types/Topic.ts
@@ -1,4 +1,4 @@
-import type { Course } from './Course'; 
+import type { Course } from "./Course";
 
 export interface Resource {
   _id: string;
@@ -6,23 +6,27 @@ export interface Resource {
   link: string;
 }
 
-export interface Topic {
-  _id: string;
+export type ResourceInput = Omit<Resource, "_id">;
+
+type BaseTopicFields = {
   title: string;
   week: number;
   summary: string;
   key_points: string[];
+  resources: ResourceInput[];
+};
+
+export interface Topic extends Omit<BaseTopicFields, "resources"> {
+  _id: string;
   resources: Resource[];
-  course: Course; 
+  course: Course;
   createdAt: string;
   updatedAt: string;
 }
 
-export type TopicInput = {
-  title: string;
-  week: number;
-  summary: string;
-  course: string; 
-  key_points: string[];
-  resources: Array<Omit<Resource, "_id">>;
+export type TopicInput = BaseTopicFields & {
+  course: string;
 };
+
+export type NewTopicInput = TopicInput;
+export type UpdateTopicInput = TopicInput & { _id: string };


### PR DESCRIPTION
# 🔀 Pull Request  
## 🔍 Summary  
This PR refactors and cleans up the Topic-related types, logic, and Vue component structure. It centralizes shared logic into a helper file, improves maintainability of the `topicStore`, and updates related files to use the new, stricter TypeScript types. It also improves the structure of component watchers and form state handling.

## 🔄 Changes Included  

- 🚀 **Add**  
  - `ResourceInput` and `BaseTopicFields` to `Topic` types for reusability  
  - `topicHelpers.ts` for shared logic (e.g. `createTopicHelper`, `updateTopicHelper`, `getCourseId`, etc.)

- 🛠 **Refactor**  
  - `Topic`, `TopicInput`, `NewTopicInput`, `UpdateTopicInput` to be more type-safe and DRY  
  - `ManageTopicForm.vue` to use helper functions and simplify setup  
  - `topicStore.ts` logic: split and simplify `saveTopic`, `handleTopicCreated`, course-topic sync logic

- 🔄 **Update**  
  - `topicService.ts` to accept new input types (`NewTopicInput`, `UpdateTopicInput`)  
  - `addTopic` and `updateTopic` in the store to match stricter type usage  
  - Moved `findCourseById` from component into `courseStore`

- ⚡ **Optimize**  
  - Component logic by removing duplicated setup and side effect handling  
  - Topic-course syncing by separating into small functions

## ✅ Benefits  
- Improve **maintainability** by centralizing shared logic into helpers  
- Improve **type safety** with clearer `TopicInput` and `UpdateTopicInput` models  
- Reduce **redundant code** in component setup and stores  
- Increase **clarity** for topic-course relationships in the store  

## 📌 Additional Notes  
- All existing topic creation and update flows have been tested with the new input/output structures  
- Backend handles ObjectId casting so frontend uses `string` for `course` in inputs  
- This structure lays foundation for testable and reusable helper logic going forward